### PR TITLE
Fixes Name Color Switching On Game Scoreboard Page

### DIFF
--- a/Stream Tool/Resources/Scripts/Game Scoreboard.js
+++ b/Stream Tool/Resources/Scripts/Game Scoreboard.js
@@ -348,7 +348,7 @@ async function getData(scInfo) {
 
 		//change the player's colors
 		if (p1ColorPrev != p1Color) {
-			updateColor('p1Color', 'p1Team', p1Color);
+			updateColor('p1Color', 'p1Name', p1Color);
 			updateScore(1, p1Score, p1Color);
 			p1ColorPrev = p1Color;
 		}
@@ -400,7 +400,7 @@ async function getData(scInfo) {
 		}
 
 		if (p2ColorPrev != p2Color) {
-			updateColor('p2Color', 'p2Team', p2Color);
+			updateColor('p2Color', 'p2Name', p2Color);
 			updateScore(2, p2Score, p2Color);
 			p2ColorPrev = p2Color;
 		}


### PR DESCRIPTION
The code targets the team name rather than the player name when updating. This leaves the player's names red+blue and changes the white team name to the chosen color.

Fix:
<img width="831" height="262" alt="image" src="https://github.com/user-attachments/assets/c512e5df-cc1b-4d33-aef3-5faad2408554" />
