### PR TITLE
Improve Larger Logo Sizes

### DIFF
--- a/Stream Tool/Game Scoreboard.html
+++ b/Stream Tool/Game Scoreboard.html
@@ -43,9 +43,13 @@
             white-space: nowrap;
         }
 
+#logo-div {
+           width: 100%;
+        }
         #logo {
-           left: 860px;
+           left: 50%;
            top: 10px;
+transform: translate(-50%, 0);
         }
 
         .mirror {
@@ -440,7 +444,7 @@
  
     <img class="absol" src="Resources/Overlay/Scoreboard.png">
 
-    <div id="logo" class="logo">
+    <div id="logo-div" class="logo">
 
         <img src="Resources/Overlay/Logo.png" id="logo" class="absol">
 

--- a/Stream Tool/VS Screen.html
+++ b/Stream Tool/VS Screen.html
@@ -40,10 +40,14 @@
             white-space: nowrap;
         }
 
+        #logo-div {
+           width: 100%;
+        }
         #logo {
-           left: 860px;
+           left: 50%;
            top: 780px;
            filter: drop-shadow(0px 0px 10px black);
+           transform: translate(-50%, 0);
         }
 
         .absol {
@@ -315,7 +319,7 @@
         </div>
 
     </div>
-    <div id="logo" class="logo">
+    <div id="logo-div" class="logo">
 
         <img src="Resources/Overlay/Logo.png" id="logo" class="absol">
 


### PR DESCRIPTION
These changes center the logo in the screen, allowing for PNG's of any size to remain centered.

Not that it usually looks the best out of ~200x200px, however this also allows for some simple details around the logo using the image itself.

### Demo for a 315x315px image:
<img width="1920" height="1080" alt="Screenshot 2025-07-28 23-55-14" src="https://github.com/user-attachments/assets/438f42e0-e4de-4a76-8de2-b6fa0dd03b9d" />
<img width="1920" height="1080" alt="Screenshot 2025-07-28 23-55-29" src="https://github.com/user-attachments/assets/a7574fae-354f-4116-a26f-e5a11dc04b75" />
